### PR TITLE
Add permissions for getting Subscription resources

### DIFF
--- a/integreatly/1.0.0/integreatly-operator.1.0.0.clusterserviceversion.yaml
+++ b/integreatly/1.0.0/integreatly-operator.1.0.0.clusterserviceversion.yaml
@@ -89,6 +89,7 @@ spec:
                 - catalogsourceconfigs
               verbs:
                 - list
+                - get
                 - create
                 - watch
       permissions:


### PR DESCRIPTION
There was an issue with failing to get existing subscriptions as we currently only have list permissions