### PR TITLE
INTLY-3511 bump solution-explorer version to 0.0.32

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MOBILE_SECURITY_SERVICE_VERSION=0.4.1
 MONITORING_VERSION=0.0.28
 NEXUS_VERSION=0.9.0
 RHSSO_VERSION=1.9.4
-TUTORIAL_WEB_APP_VERSION=0.0.31
+TUTORIAL_WEB_APP_VERSION=0.0.32
 UPS_VERSION=0.2.0
 
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "${QUAY_PASSWORD}"}}' | jq -r '.token')

--- a/integreatly-solution-explorer/solution-explorer-0.0.32/solution-explorer-operator.v0.0.31.clusterserviceversion.yaml
+++ b/integreatly-solution-explorer/solution-explorer-0.0.32/solution-explorer-operator.v0.0.31.clusterserviceversion.yaml
@@ -1,0 +1,145 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Basic Install
+  name: solution-explorer-operator.v0.0.32
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: WebApp
+        name: webapps.integreatly.org
+        version: v1alpha1
+        displayName: SolutionExplorer
+        description: SolutionExplorer
+  description: Placeholder description
+  displayName: Tutorial Web App Operator
+  install:
+    spec:
+      deployments:
+        - name: tutorial-web-app-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: tutorial-web-app-operator
+            strategy: {}
+            template:
+              metadata:
+                labels:
+                  name: tutorial-web-app-operator
+              spec:
+                containers:
+                  - command:
+                      - tutorial-web-app-operator
+                    env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.annotations['olm.targetNamespaces']
+                      - name: OPERATOR_NAME
+                        value: tutorial-web-app-operator
+                    image: quay.io/integreatly/tutorial-web-app-operator:v0.0.32
+                    imagePullPolicy: Always
+                    name: tutorial-web-app-operator
+                    ports:
+                      - containerPort: 60000
+                        name: metrics
+                    resources: {}
+                serviceAccountName: tutorial-web-app-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - integreatly.org
+              resources:
+                - '*'
+              verbs:
+                - '*'
+            - apiGroups:
+                - ""
+              resources:
+                - pods
+                - services
+                - endpoints
+                - persistentvolumeclaims
+                - events
+                - configmaps
+                - secrets
+                - serviceaccounts
+              verbs:
+                - '*'
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
+                - daemonsets
+                - replicasets
+                - statefulsets
+              verbs:
+                - '*'
+            - apiGroups:
+                - template.openshift.io
+              resources:
+                - processedtemplates
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - watch
+            - apiGroups:
+                - image.openshift.io
+              resources:
+                - imagestreams
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - watch
+            - apiGroups:
+                - apps.openshift.io
+              resources:
+                - deploymentconfigs
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - watch
+            - apiGroups:
+                - route.openshift.io
+              resources:
+                - routes
+                - routes/custom-host
+              verbs:
+                - get
+                - list
+                - create
+                - update
+                - delete
+                - deletecollection
+                - watch
+          serviceAccountName: tutorial-web-app-operator
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+  maturity: alpha
+  provider: {}
+  version: 0.0.32
+  replaces: solution-explorer-operator.v0.0.31

--- a/integreatly-solution-explorer/solution-explorer-0.0.32/webapp.crd.yaml
+++ b/integreatly-solution-explorer/solution-explorer-0.0.32/webapp.crd.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: webapps.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: WebApp
+    listKind: WebAppList
+    plural: webapps
+    singular: webapp
+    shortNames:
+      - wa
+  scope: Namespaced
+  version: v1alpha1
+  additionalPrinterColumns:
+    - name: status
+      description: webapp current status
+      type: string
+      JSONPath: .status.message
+    - name: created
+      description: webapp date creation
+      type: date
+      JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            app_label:
+              type: string
+            template:
+              type: object
+              properties:
+                path:
+                  type: string
+                parameters:
+                  type: object

--- a/integreatly-solution-explorer/solution-explorer-operator.package.yaml
+++ b/integreatly-solution-explorer/solution-explorer-operator.package.yaml
@@ -1,4 +1,4 @@
 packageName: integreatly-solution-explorer
 channels:
-- currentCSV: solution-explorer-operator.v0.0.31
+- currentCSV: solution-explorer-operator.v0.0.32
   name: integreatly


### PR DESCRIPTION
New version of solution explorer to capture changes made in https://github.com/integr8ly/tutorial-web-app/pull/521.

Related PR: https://github.com/integr8ly/tutorial-web-app-operator/pull/71

## Verification Steps
1. Create an operator source that points to `jameelb` app registry
2. Ensure solution explorer CSV is made available to your cluster
3. Ensure solution explorer can be deployed and uses the version `2.19.1`
